### PR TITLE
Fix building on non-windows platforms & add workflow test targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,14 +11,32 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - os: windows-latest
+          target: i686-pc-windows-gnu
+        - os: windows-latest
+          target: i686-pc-windows-msvc
+        - os: ubuntu-latest
+          target: i686-unknown-linux-gnu
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: windows-latest
+          target: x86_64-pc-windows-gnu
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
 
-    runs-on: windows-latest
-
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - uses: taiki-e/install-action@cargo-hack
-    - name: Check
-      run: cargo hack check --rust-version --all-targets --ignore-private
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ strip = "symbols"
 clap = "4.5.1"
 json = { version = "0.12.4", default-features = false }
 ureq = { version = "2.9.6", default-features = false }
+
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = [
     "consoleapi",
     "processenv",

--- a/build.rs
+++ b/build.rs
@@ -1,45 +1,51 @@
 #[cfg(windows)]
 extern crate windres;
 
-use std::env;
-use std::fs;
-use std::path::Path;
-
-#[cfg(windows)]
-use windres::Build;
-
-#[cfg(windows)]
 fn main() {
-    let out_dir = env::var_os("OUT_DIR").unwrap();
-    let resource_header = Path::new(&out_dir).join("versions.h");
+    #[cfg(windows)]
+    windows::compile_resources_file();
+}
 
-    // Write include file for resource parameters based on cargo settings
-    let major = env!("CARGO_PKG_VERSION_MAJOR");
-    let minor = env!("CARGO_PKG_VERSION_MINOR");
-    let patch = env!("CARGO_PKG_VERSION_PATCH");
-    let full = env!("CARGO_PKG_VERSION");
-    let description = env!("CARGO_PKG_DESCRIPTION");
-    let auhtor = env!("CARGO_PKG_AUTHORS");
-    let name = env!("CARGO_PKG_NAME");
+#[cfg(windows)]
+mod windows {
+    use std::env;
+    use std::fs;
+    use std::path::Path;
 
-    fs::write(
-        resource_header,
-        format!(
-            "
-#define VERSION_MAJOR {major}
-#define VERSION_MINOR {minor}
-#define VERSION_PATCH {patch}
-#define VERSION_FULL \"{full}\"
-#define VERSION_DESCRIPTION  \"{description}\"
-#define VERSION_AUTHOR  \"{auhtor}\"
-#define VERSION_NAME \"{name}\"
-"
-        )
-    ).unwrap();
+    use windres::Build;
+    
+    pub fn compile_resources_file() {
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+        let resource_header = Path::new(&out_dir).join("versions.h");
 
-    Build::new().include(out_dir).compile("resources.rc").unwrap();
+        // Write include file for resource parameters based on cargo settings
+        let major = env!("CARGO_PKG_VERSION_MAJOR");
+        let minor = env!("CARGO_PKG_VERSION_MINOR");
+        let patch = env!("CARGO_PKG_VERSION_PATCH");
+        let full = env!("CARGO_PKG_VERSION");
+        let description = env!("CARGO_PKG_DESCRIPTION");
+        let auhtor = env!("CARGO_PKG_AUTHORS");
+        let name = env!("CARGO_PKG_NAME");
 
-    // println!("cargo:rerun-if-changed=resources.rc"); // windres already does this
-    //println!("cargo:rerun-if-changed=hank.ico");
-    println!("cargo:rerun-if-changed=app.manifest");
+        fs::write(
+            resource_header,
+            format!(
+                "
+    #define VERSION_MAJOR {major}
+    #define VERSION_MINOR {minor}
+    #define VERSION_PATCH {patch}
+    #define VERSION_FULL \"{full}\"
+    #define VERSION_DESCRIPTION  \"{description}\"
+    #define VERSION_AUTHOR  \"{auhtor}\"
+    #define VERSION_NAME \"{name}\"
+    "
+            )
+        ).unwrap();
+
+        Build::new().include(out_dir).compile("resources.rc").unwrap();
+
+        // println!("cargo:rerun-if-changed=resources.rc"); // windres already does this
+        //println!("cargo:rerun-if-changed=hank.ico");
+        println!("cargo:rerun-if-changed=app.manifest");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,10 @@ use std::thread::sleep;
 use std::time::{ Duration, Instant };
 
 mod colors;
-use colors::fix_ansicolor;
 use colors::Colorize;
+
+#[cfg(target_os = "windows")]
+use colors::fix_ansicolor;
 
 fn get_arg<T: AsRef<str>>(matches: &ArgMatches, key: T) -> Option<&str> {
     matches.get_one::<String>(key.as_ref()).map(|s| s.as_str())


### PR DESCRIPTION
This PR aims to fix building & running on non-windows platforms.

- Declared `winapi` as a dependency only for windows builds.
- Moved windows-only code from the `main` build function to a different function.
- Declared `colors::fix_ansicolor` as windows-only.
- Modify Rust workflow to build & test using all current [tier 1](https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools) targets.